### PR TITLE
update yo spira:composer to be compatible with devtools 1.0.1

### DIFF
--- a/generators/composer/index.js
+++ b/generators/composer/index.js
@@ -28,7 +28,7 @@ module.exports = generators.Base.extend({
             description: "Rebuild optimised composer autoload files"
         },
         '*' : {
-            args: ['ssh', '--command', 'cd /data && docker-compose run --entrypoint php devtools /usr/bin/composer <%= process.argv.slice(3).join(" ") %> --working-dir api'],
+            args: ['ssh', '--command', 'cd /data && docker-compose run --entrypoint /usr/bin/composer devtools <%= process.argv.slice(3).join(" ") %> --working-dir api'],
             description: 'Run arbitrary composer command'
         }
 


### PR DESCRIPTION
This allows composer commands to continue working with devtools 1.0.1 and is backwards compatible with earlier devtools containers
